### PR TITLE
Disable persist-credentials where git push is not needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Wait for checks to pass
         uses: fountainhead/action-wait-for-check@v1.2.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v6
         with:


### PR DESCRIPTION
## Summary
- Set `persist-credentials: false` on `actions/checkout` in the `auto-merge` and `deploy` workflows, where later steps do not rely on persisted git credentials.
- Left the `build` job unchanged because `git-auto-commit-action` still needs checkout to persist credentials for commit/push.

## Test plan
- [ ] CI `build` job still auto-commits lint/format fixes on PRs
- [ ] Dependabot `auto-merge` job still merges PRs after checks pass
- [ ] `deploy` workflow still publishes to `gh-pages` via `ACCESS_TOKEN`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to modify Git credential handling during checkout operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->